### PR TITLE
Add default dismiss handler for iOS (still need to work out how to do…

### DIFF
--- a/src/Plugin.LocalNotifications.Abstractions/ILocalNotificationActionRegistrar.cs
+++ b/src/Plugin.LocalNotifications.Abstractions/ILocalNotificationActionRegistrar.cs
@@ -8,10 +8,16 @@ namespace Plugin.LocalNotifications.Abstractions
         /// Register an action to be used with notifications
         /// </summary>
         /// <param name="title">Unique display name for the action</param>
-        /// <param name="iconId">Icon identifier for display purposes</param>
         /// <param name="action">Action to be performed when action is selected, parameter is specified when action is applied to a notification</param>
         /// <returns></returns>
-        ILocalNotificationActionRegistrar WithActionHandler(string title, int iconId, Action<string> action);
+        ILocalNotificationActionRegistrar WithActionHandler(string title, Action<string> action);
+
+        /// <summary>
+        /// Registers the default dismiss action to be used when the user swipes a notification
+        /// </summary>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        ILocalNotificationActionRegistrar WithDismissActionHandler(Action<string> action);
 
         /// <summary>
         /// Finish registration
@@ -26,9 +32,16 @@ namespace Plugin.LocalNotifications.Abstractions
 
     public class LocalNotificationActionRegistration
     {
+        public const string DismissActionIdentifier = "DismissActionIdentifier";
+
         public string ActionSetId { get; set; }
-        public string Title { get; set; }
+        public string Id { get; set; }
         public int IconId { get; set; }
         public Action<string> Action { get; set; }
+    }
+
+    public class ButtonLocalNotificationActionRegistration : LocalNotificationActionRegistration
+    {
+        public string Title { get; set; }
     }
 }

--- a/src/Plugin.LocalNotifications.Android/LocalNotificationActionReceiver.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationActionReceiver.cs
@@ -39,7 +39,7 @@ namespace Plugin.LocalNotifications
         {
             var actionSetId = intent.HasExtra(LocalNotificationActionSetId) ? intent.GetStringExtra(LocalNotificationActionSetId) : null;
             var actionId = intent.HasExtra(LocalNotificationActionId) ? intent.GetStringExtra(LocalNotificationActionId) : null;
-            var action = GetRegisteredActions(actionSetId).FirstOrDefault(a => a.Title == actionId);
+            var action = GetRegisteredActions(actionSetId).FirstOrDefault(a => a.Id == actionId);
 
             if (action != null)
             {

--- a/src/Plugin.LocalNotifications.Android/LocalNotificationActionRegistrar.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationActionRegistrar.cs
@@ -12,25 +12,36 @@ namespace Plugin.LocalNotifications
             Id = id;
         }
 
-        public ILocalNotificationActionRegistrar WithActionHandler(string title, int iconId, Action<string> action)
+        public ILocalNotificationActionRegistrar WithActionHandler(string title, Action<string> action)
         {
-            if (RegisteredActions.Any(a => a.Title == title))
+            if (RegisteredActions.Any(a => a.Id == title))
             {
                 throw new InvalidOperationException($"Could not register action {title} into action set {Id} because one has with the same name ahs already been registered");
             }
 
-            RegisteredActions.Add(new LocalNotificationActionRegistration
+            RegisteredActions.Add(new ButtonLocalNotificationActionRegistration
             {
                 ActionSetId = Id,
+                Id = title,
                 Title = title,
-                IconId = iconId,
                 Action = action
             });
 
             return this;
         }
 
-        // TODO: Consider removing
+        public ILocalNotificationActionRegistrar WithDismissActionHandler(Action<string> action)
+        {
+            RegisteredActions.Add(new LocalNotificationActionRegistration
+            {
+                Id = LocalNotificationActionRegistration.DismissActionIdentifier,
+                ActionSetId = Id,
+                Action = action
+            });
+
+            return this;
+        }
+
         public void Register()
         {
             // Do nothing

--- a/src/Plugin.LocalNotifications.Android/LocalNotificationBuilder.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationBuilder.cs
@@ -53,7 +53,7 @@ namespace Plugin.LocalNotifications
                 throw new InvalidOperationException($"Unable to associate action set id {actionSetId} with notification because it has not been registered.");
             }
 
-            foreach (var action in registeredActions)
+            foreach (var action in registeredActions.OfType<ButtonLocalNotificationActionRegistration>())
             {
                 _actions.Add(new LocalNotificationAction
                 {

--- a/src/Plugin.LocalNotifications.iOS/LocalNotificationBuilder.cs
+++ b/src/Plugin.LocalNotifications.iOS/LocalNotificationBuilder.cs
@@ -109,7 +109,7 @@ namespace Plugin.LocalNotifications
 
             if (_actionSetId != null)
             {
-                userInfo.SetValueForKey(NSObject.FromObject(_actionSetParameter), new NSString(UserNotificationCenter.LocalNotificationActionParameterKey));
+                userInfo.SetValueForKey(NSObject.FromObject(_actionSetParameter), new NSString(UserNotificationCenterDelegate.LocalNotificationActionParameterKey));
             }
 
             return userInfo;

--- a/src/Plugin.LocalNotifications.iOS/LocalNotifications.cs
+++ b/src/Plugin.LocalNotifications.iOS/LocalNotifications.cs
@@ -13,16 +13,14 @@ namespace Plugin.LocalNotifications
     {
         public const string NotificationKey = "LocalNotificationKey";
 
-        private readonly UserNotificationCenter _userNotificationCenter; 
+        public readonly UserNotificationCenterDelegate UserNotificationCenterDelegate; 
 
         public LocalNotifications()
         {
-            _userNotificationCenter = new UserNotificationCenter();
-
-            UNUserNotificationCenter.Current.Delegate = _userNotificationCenter;
+            UserNotificationCenterDelegate = new UserNotificationCenterDelegate();
         }
 
-        public ILocalNotificationActionRegistrar RegisterActionSet(string id) => _userNotificationCenter.NewActionRegistrar(id);
+        public ILocalNotificationActionRegistrar RegisterActionSet(string id) => UserNotificationCenterDelegate.NewActionRegistrar(id);
 
         public ILocalNotificationBuilder New(int id) => new LocalNotificationBuilder(id);
 

--- a/src/Plugin.LocalNotifications.iOS/Plugin.LocalNotifications.iOS.csproj
+++ b/src/Plugin.LocalNotifications.iOS/Plugin.LocalNotifications.iOS.csproj
@@ -107,7 +107,7 @@
     <Compile Include="LocalNotificationBuilder.cs" />
     <Compile Include="LocalNotifications.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UserNotificationCenter.cs" />
+    <Compile Include="UserNotificationCenterDelegate.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Add ability to register a default dismiss handler. Currently only works for iOS.
Selecting or swiping the notification will run the dismiss action.